### PR TITLE
Improve rastermanip resolution utilities

### DIFF
--- a/pyfastflow/rastermanip/downscaling.py
+++ b/pyfastflow/rastermanip/downscaling.py
@@ -10,23 +10,21 @@ using the specified aggregation method.
 Author: B.G.
 """
 
-import taichi as ti
 import numpy as np
+import taichi as ti
+
 from .. import pool
 
 
 @ti.kernel
 def halve_resolution_kernel_max(
-    source_field: ti.template(), 
-    target_field: ti.template(), 
-    nx: ti.i32, 
-    ny: ti.i32
+    source_field: ti.template(), target_field: ti.template(), nx: ti.i32, ny: ti.i32
 ):
     """
     Halve resolution using maximum value aggregation.
-    
+
     Each 2x2 block in source becomes 1 cell in target using the maximum value.
-    
+
     Args:
         source_field: Original field (nx * ny elements)
         target_field: Output field ((nx/2) * (ny/2) elements)
@@ -36,48 +34,45 @@ def halve_resolution_kernel_max(
     # Process each cell in the target (downscaled) grid
     target_nx = nx // 2
     target_ny = ny // 2
-    
+
     for target_idx in target_field:
         # Convert target flat index to 2D coordinates
         target_j = target_idx // target_nx
         target_i = target_idx % target_nx
-        
+
         # Skip out of range
         if target_j >= target_ny or target_i >= target_nx:
             continue
-            
+
         # Find corresponding 2x2 block in source
         source_base_j = target_j * 2
         source_base_i = target_i * 2
-        
+
         # Find maximum value in the 2x2 block
         max_val = -1e30
         for sub_j in ti.static(range(2)):
             for sub_i in ti.static(range(2)):
                 source_j = source_base_j + sub_j
                 source_i = source_base_i + sub_i
-                
+
                 # Check bounds
                 if source_j < ny and source_i < nx:
                     source_idx = source_j * nx + source_i
                     val = source_field[source_idx]
                     max_val = ti.max(max_val, val)
-        
+
         target_field[target_idx] = max_val
 
 
 @ti.kernel
 def halve_resolution_kernel_min(
-    source_field: ti.template(), 
-    target_field: ti.template(), 
-    nx: ti.i32, 
-    ny: ti.i32
+    source_field: ti.template(), target_field: ti.template(), nx: ti.i32, ny: ti.i32
 ):
     """
     Halve resolution using minimum value aggregation.
-    
+
     Each 2x2 block in source becomes 1 cell in target using the minimum value.
-    
+
     Args:
         source_field: Original field (nx * ny elements)
         target_field: Output field ((nx/2) * (ny/2) elements)
@@ -86,44 +81,41 @@ def halve_resolution_kernel_min(
     """
     target_nx = nx // 2
     target_ny = ny // 2
-    
+
     for target_idx in target_field:
         target_j = target_idx // target_nx
         target_i = target_idx % target_nx
-        
+
         if target_j >= target_ny or target_i >= target_nx:
             continue
-            
+
         source_base_j = target_j * 2
         source_base_i = target_i * 2
-        
+
         # Find minimum value in the 2x2 block
         min_val = 1e30
         for sub_j in ti.static(range(2)):
             for sub_i in ti.static(range(2)):
                 source_j = source_base_j + sub_j
                 source_i = source_base_i + sub_i
-                
+
                 if source_j < ny and source_i < nx:
                     source_idx = source_j * nx + source_i
                     val = source_field[source_idx]
                     min_val = ti.min(min_val, val)
-        
+
         target_field[target_idx] = min_val
 
 
 @ti.kernel
 def halve_resolution_kernel_mean(
-    source_field: ti.template(), 
-    target_field: ti.template(), 
-    nx: ti.i32, 
-    ny: ti.i32
+    source_field: ti.template(), target_field: ti.template(), nx: ti.i32, ny: ti.i32
 ):
     """
     Halve resolution using mean value aggregation.
-    
+
     Each 2x2 block in source becomes 1 cell in target using the arithmetic mean.
-    
+
     Args:
         source_field: Original field (nx * ny elements)
         target_field: Output field ((nx/2) * (ny/2) elements)
@@ -132,17 +124,17 @@ def halve_resolution_kernel_mean(
     """
     target_nx = nx // 2
     target_ny = ny // 2
-    
+
     for target_idx in target_field:
         target_j = target_idx // target_nx
         target_i = target_idx % target_nx
-        
+
         if target_j >= target_ny or target_i >= target_nx:
             continue
-            
+
         source_base_j = target_j * 2
         source_base_i = target_i * 2
-        
+
         # Calculate mean of 2x2 block
         sum_val = 0.0
         count = 0
@@ -150,13 +142,13 @@ def halve_resolution_kernel_mean(
             for sub_i in ti.static(range(2)):
                 source_j = source_base_j + sub_j
                 source_i = source_base_i + sub_i
-                
+
                 if source_j < ny and source_i < nx:
                     source_idx = source_j * nx + source_i
                     val = source_field[source_idx]
                     sum_val += val
                     count += 1
-        
+
         if count > 0:
             target_field[target_idx] = sum_val / count
         else:
@@ -164,14 +156,16 @@ def halve_resolution_kernel_mean(
 
 
 @ti.func
-def cubic_interpolate(v0: ti.f32, v1: ti.f32, v2: ti.f32, v3: ti.f32, t: ti.f32) -> ti.f32:
+def cubic_interpolate(
+    v0: ti.f32, v1: ti.f32, v2: ti.f32, v3: ti.f32, t: ti.f32
+) -> ti.f32:
     """
     Cubic interpolation between 4 points.
-    
+
     Args:
         v0, v1, v2, v3: Four consecutive values
         t: Interpolation parameter [0, 1]
-    
+
     Returns:
         Interpolated value
     """
@@ -179,23 +173,23 @@ def cubic_interpolate(v0: ti.f32, v1: ti.f32, v2: ti.f32, v3: ti.f32, t: ti.f32)
     b = v0 - 2.5 * v1 + 2.0 * v2 - 0.5 * v3
     c = -0.5 * v0 + 0.5 * v2
     d = v1
-    
+
     return a * t * t * t + b * t * t + c * t + d
 
 
 @ti.kernel
 def halve_resolution_kernel_cubic(
-    source_field: ti.template(), 
-    target_field: ti.template(), 
-    nx: ti.i32, 
-    ny: ti.i32
+    source_field: ti.template(),
+    target_field: ti.template(),
+    nx: ti.i32,
+    ny: ti.i32,
 ):
     """
-    Halve resolution using cubic interpolation.
-    
-    Each 2x2 block in source becomes 1 cell in target using cubic interpolation
-    of the surrounding area for smooth downsampling.
-    
+    Halve resolution using true bicubic interpolation.
+
+    Each 2x2 block in source becomes 1 cell in target by sampling a 4x4
+    neighborhood with cubic interpolation along both axes.
+
     Args:
         source_field: Original field (nx * ny elements)
         target_field: Output field ((nx/2) * (ny/2) elements)
@@ -204,128 +198,124 @@ def halve_resolution_kernel_cubic(
     """
     target_nx = nx // 2
     target_ny = ny // 2
-    
+
     for target_idx in target_field:
         target_j = target_idx // target_nx
         target_i = target_idx % target_nx
-        
+
         if target_j >= target_ny or target_i >= target_nx:
             continue
-        
+
         # Center of the target cell in source coordinates
         center_j = target_j * 2.0 + 0.5
         center_i = target_i * 2.0 + 0.5
-        
-        # For simplicity, use bilinear interpolation as a cubic approximation
-        # Get the 4 nearest source cells for interpolation
-        base_j = ti.cast(center_j, ti.i32)
-        base_i = ti.cast(center_i, ti.i32)
-        
+
+        base_j = ti.floor(center_j, dtype=ti.i32)
+        base_i = ti.floor(center_i, dtype=ti.i32)
         frac_j = center_j - base_j
         frac_i = center_i - base_i
-        
-        # Sample 2x2 area around the center point
-        sum_val = 0.0
-        total_weight = 0.0
-        
-        for dj in ti.static(range(2)):
-            for di in ti.static(range(2)):
-                sample_j = base_j + dj
-                sample_i = base_i + di
-                
-                if sample_j >= 0 and sample_j < ny and sample_i >= 0 and sample_i < nx:
-                    source_idx = sample_j * nx + sample_i
-                    val = source_field[source_idx]
-                    
-                    # Bilinear weights
-                    weight_j = (1.0 - frac_j) if dj == 0 else frac_j
-                    weight_i = (1.0 - frac_i) if di == 0 else frac_i
-                    weight = weight_j * weight_i
-                    
-                    sum_val += val * weight
-                    total_weight += weight
-        
-        if total_weight > 0:
-            target_field[target_idx] = sum_val / total_weight
-        else:
-            target_field[target_idx] = 0.0
+
+        row_vals = ti.Vector([0.0, 0.0, 0.0, 0.0])
+        for dj in ti.static(range(4)):
+            samples = ti.Vector([0.0, 0.0, 0.0, 0.0])
+            jj = ti.min(ti.max(base_j + dj - 1, 0), ny - 1)
+            for di in ti.static(range(4)):
+                ii = ti.min(ti.max(base_i + di - 1, 0), nx - 1)
+                source_idx = jj * nx + ii
+                samples[di] = source_field[source_idx]
+            row_vals[dj] = cubic_interpolate(
+                samples[0], samples[1], samples[2], samples[3], frac_i
+            )
+
+        target_field[target_idx] = cubic_interpolate(
+            row_vals[0], row_vals[1], row_vals[2], row_vals[3], frac_j
+        )
 
 
 def halve_resolution(
     grid_data,
-    method: str = 'mean',
-    return_field: bool = False
+    method: str = "mean",
+    return_field: bool = False,
+    nx: int | None = None,
+    ny: int | None = None,
 ):
     """
     Halve the resolution of a 2D grid using specified aggregation method.
-    
+
     Reduces a grid to half resolution in both dimensions by aggregating 2x2 blocks
     of cells into single cells using the specified method.
-    
+
     Args:
         grid_data: Input grid data (numpy array or Taichi field)
-                  Expected shape: (ny, nx) for numpy or nx*ny for flat Taichi field
+                  Expected shape: (ny, nx) for numpy arrays or Taichi fields
         method: Aggregation method ('max', 'min', 'mean', 'cubic') (default: 'mean')
         return_field: If True, return Taichi field; if False, return numpy array (default: False)
-    
+        nx: Number of columns when providing a 1D Taichi field
+        ny: Number of rows when providing a 1D Taichi field
+
     Returns:
         numpy.ndarray or taichi.Field: Downscaled grid with shape (ny//2, nx//2)
-        
+
     Example:
         # Halve resolution using mean aggregation
         downscaled = halve_resolution(terrain_data, method='mean')
-        
+
         # Use maximum values for conservative downsampling
         max_downscaled = halve_resolution(terrain_data, method='max')
-        
+
         # Smooth downsampling with cubic interpolation
         smooth_downscaled = halve_resolution(terrain_data, method='cubic')
     """
     # Validate method
-    valid_methods = ['max', 'min', 'mean', 'cubic']
+    valid_methods = ["max", "min", "mean", "cubic"]
     if method not in valid_methods:
         raise ValueError(f"Method must be one of {valid_methods}, got '{method}'")
-    
+
     # Handle input conversion
     if isinstance(grid_data, np.ndarray):
         if len(grid_data.shape) != 2:
             raise ValueError("Input numpy array must be 2D")
         ny, nx = grid_data.shape
-        
-        # Check that dimensions are even
-        if nx % 2 != 0 or ny % 2 != 0:
-            raise ValueError(f"Grid dimensions must be even for halving. Got ({ny}, {nx})")
-        
-        # Create source field and copy data
-        source_field = pool.get_temp_field(ti.f32, (ny * nx,))
-        source_field.field.from_numpy(grid_data.flatten())
+        data_np = grid_data.flatten()
+    elif hasattr(grid_data, "to_numpy"):
+        if len(grid_data.shape) == 2:
+            ny, nx = grid_data.shape
+            data_np = grid_data.to_numpy().reshape(-1)
+        elif len(grid_data.shape) == 1:
+            total_size = grid_data.shape[0]
+            if nx is None or ny is None:
+                raise ValueError("nx and ny must be provided for 1D Taichi fields")
+            if nx * ny != total_size:
+                raise ValueError("nx * ny does not match the size of the Taichi field")
+            data_np = grid_data.to_numpy()
+        else:
+            raise ValueError("Input Taichi field must be 1D or 2D")
     else:
-        # Assume Taichi field - need to determine dimensions
-        total_size = grid_data.shape[0] if hasattr(grid_data, 'shape') else len(grid_data)
-        nx = ny = int(np.sqrt(total_size))
-        if nx * ny != total_size:
-            raise ValueError("Cannot determine grid dimensions from Taichi field. Please use square grid or convert to numpy first.")
-        if nx % 2 != 0 or ny % 2 != 0:
-            raise ValueError(f"Grid dimensions must be even for halving. Got ({ny}, {nx})")
-        source_field = pool.get_temp_field(ti.f32, (total_size,))
-        # Assume field is already populated
-    
+        raise TypeError("grid_data must be a numpy array or Taichi field")
+
+    if nx % 2 != 0 or ny % 2 != 0:
+        raise ValueError(f"Grid dimensions must be even for halving. Got ({ny}, {nx})")
+
+    # Create source field and copy data
+    source_field = pool.get_temp_field(ti.f32, (ny * nx,))
+    source_field.field.from_numpy(data_np)
+
     # Create target field for downscaled result
     target_nx = nx // 2
     target_ny = ny // 2
     target_size = target_ny * target_nx
     target_field = pool.get_temp_field(ti.f32, (target_size,))
-    
+
     # Select and execute appropriate kernel
-    if method == 'max':
+    if method == "max":
         halve_resolution_kernel_max(source_field.field, target_field.field, nx, ny)
-    elif method == 'min':
+    elif method == "min":
         halve_resolution_kernel_min(source_field.field, target_field.field, nx, ny)
-    elif method == 'mean':
+    elif method == "mean":
         halve_resolution_kernel_mean(source_field.field, target_field.field, nx, ny)
-    elif method == 'cubic':
+    elif method == "cubic":
         halve_resolution_kernel_cubic(source_field.field, target_field.field, nx, ny)
-    
+
     if return_field:
         # Release source field and return target field
         source_field.release()

--- a/pyfastflow/rastermanip/upscaling.py
+++ b/pyfastflow/rastermanip/upscaling.py
@@ -12,57 +12,60 @@ The upscaling algorithm:
 Author: B.G.
 """
 
-import taichi as ti
 import numpy as np
+import taichi as ti
+
 from .. import pool
 from ..grid import neighbourer_flat_param as nei
 
 
 @ti.func
-def get_slope_direction(source_field: ti.template(), idx: ti.i32, nx: ti.i32, ny: ti.i32) -> ti.Vector:
+def get_slope_direction(
+    source_field: ti.template(), idx: ti.i32, nx: ti.i32, ny: ti.i32
+) -> ti.Vector:
     """
     Compute slope direction vector for a given cell.
-    
+
     Args:
         source_field: Original field to analyze
         idx: Flat index of the cell
         nx: Number of columns in original grid
         ny: Number of rows in original grid
-        
+
     Returns:
         ti.Vector: Normalized slope direction (dx, dy)
     """
     center_val = source_field[idx]
-    
+
     # Initialize gradient components
     grad_x = 0.0
     grad_y = 0.0
     valid_neighbors = 0
-    
+
     # Check all 4 cardinal neighbors for gradient computation
     for k in ti.static(range(4)):
         neighbor_idx = nei.neighbour_n_param(idx, k, nx, ny)
         if neighbor_idx != -1:
             neighbor_val = source_field[neighbor_idx]
             diff = center_val - neighbor_val
-            
+
             # Convert direction to gradient components
-            if k == 0:      # top
+            if k == 0:  # top
                 grad_y += diff
-            elif k == 1:    # left  
+            elif k == 1:  # left
                 grad_x += diff
-            elif k == 2:    # right
+            elif k == 2:  # right
                 grad_x -= diff
-            elif k == 3:    # bottom
+            elif k == 3:  # bottom
                 grad_y -= diff
-            
+
             valid_neighbors += 1
-    
+
     # Normalize gradient
     if valid_neighbors > 0:
         grad_x /= valid_neighbors
         grad_y /= valid_neighbors
-        
+
     # Return normalized direction vector
     magnitude = ti.sqrt(grad_x * grad_x + grad_y * grad_y)
     result = ti.Vector([0.0, 0.0])
@@ -73,45 +76,43 @@ def get_slope_direction(source_field: ti.template(), idx: ti.i32, nx: ti.i32, ny
 
 @ti.kernel
 def double_resolution_kernel(
-    source_field: ti.template(), 
-    target_field: ti.template(), 
-    nx: ti.i32, 
+    source_field: ti.template(),
+    target_field: ti.template(),
+    nx: ti.i32,
     ny: ti.i32,
     noise_amplitude: ti.f32,
-    seed: ti.i32
 ):
     """
     Double the resolution of a 2D field with slope-preserving interpolation.
-    
+
     Each cell in the source becomes 4 cells in the target (2x2 block).
     Interpolation preserves the slope direction determined from neighbors.
-    
+
     Args:
         source_field: Original field (nx * ny elements)
-        target_field: Output field (2*nx * 2*ny elements)  
+        target_field: Output field (2*nx * 2*ny elements)
         nx: Number of columns in original grid
         ny: Number of rows in original grid
         noise_amplitude: Amplitude of random noise to add
-        seed: Random seed for reproducible noise
     """
     # Process each cell in the original grid
     for idx in source_field:
         # Convert flat index to 2D coordinates
         j = idx // nx  # row
-        i = idx % nx   # column
-        
+        i = idx % nx  # column
+
         # Skip boundary conditions that are out of range
         if j >= ny or i >= nx:
             continue
-            
+
         # Get slope direction for this cell
         slope_dir = get_slope_direction(source_field, idx, nx, ny)
         center_val = source_field[idx]
-        
+
         # Calculate base interpolation strength (quarter of the slope magnitude)
         base_interp = ti.abs(slope_dir[0]) + ti.abs(slope_dir[1])
         interp_strength = base_interp * 0.25
-        
+
         # Generate the 4 new cells (2x2 block) in target grid
         for sub_j in ti.static(range(2)):
             for sub_i in ti.static(range(2)):
@@ -119,19 +120,21 @@ def double_resolution_kernel(
                 target_j = j * 2 + sub_j
                 target_i = i * 2 + sub_i
                 target_idx = target_j * (nx * 2) + target_i
-                
+
                 # Relative position within the 2x2 block ([-0.5, +0.5])
-                rel_x = (sub_i - 0.5) * 0.5
-                rel_y = (sub_j - 0.5) * 0.5
-                
+                rel_x = sub_i - 0.5
+                rel_y = sub_j - 0.5
+
                 # Apply slope-based interpolation
-                slope_contribution = (slope_dir[0] * rel_x + slope_dir[1] * rel_y) * interp_strength
+                slope_contribution = (
+                    slope_dir[0] * rel_x + slope_dir[1] * rel_y
+                ) * interp_strength
                 interpolated_val = center_val + slope_contribution
-                
+
                 # Add controlled noise (order of magnitude lower)
                 noise_factor = noise_amplitude * 0.1 * interp_strength
                 noise_val = (ti.random(ti.f32) - 0.5) * 2.0 * noise_factor
-                
+
                 # Final value
                 final_val = interpolated_val + noise_val
                 target_field[target_idx] = final_val
@@ -140,31 +143,33 @@ def double_resolution_kernel(
 def double_resolution(
     grid_data,
     noise_amplitude: float = 0.0,
-    seed: int = 42,
-    return_field: bool = False
+    return_field: bool = False,
+    nx: int | None = None,
+    ny: int | None = None,
 ):
     """
     Double the resolution of a 2D grid with slope-preserving interpolation.
-    
+
     Creates a new grid with 2x resolution in both dimensions. Each original cell
     becomes a 2x2 block of cells with values interpolated based on local slope
     direction to preserve terrain characteristics.
-    
+
     Args:
         grid_data: Input grid data (numpy array or Taichi field)
-                  Expected shape: (ny, nx) for numpy or nx*ny for flat Taichi field
+                  Expected shape: (ny, nx) for numpy arrays or Taichi fields
         noise_amplitude: Amplitude of noise to add for realism (default: 0.0)
                         Noise is scaled down by factor of 10 relative to interpolation
-        seed: Random seed for reproducible noise generation (default: 42)
         return_field: If True, return Taichi field; if False, return numpy array (default: False)
-    
+        nx: Number of columns when providing a 1D Taichi field
+        ny: Number of rows when providing a 1D Taichi field
+
     Returns:
         numpy.ndarray or taichi.Field: Upscaled grid with shape (2*ny, 2*nx)
-        
+
     Example:
         # Double resolution of a 100x100 grid with small noise
         upscaled = double_resolution(terrain_data, noise_amplitude=0.1)
-        
+
         # Return as Taichi field for further GPU processing
         upscaled_field = double_resolution(terrain_data, return_field=True)
     """
@@ -173,35 +178,40 @@ def double_resolution(
         if len(grid_data.shape) != 2:
             raise ValueError("Input numpy array must be 2D")
         ny, nx = grid_data.shape
-        
-        # Create source field and copy data
-        source_field = pool.get_temp_field(ti.f32, (ny * nx,))
-        source_field.field.from_numpy(grid_data.flatten())
+        data_np = grid_data.flatten()
+    elif hasattr(grid_data, "to_numpy"):
+        if len(grid_data.shape) == 2:
+            ny, nx = grid_data.shape
+            data_np = grid_data.to_numpy().reshape(-1)
+        elif len(grid_data.shape) == 1:
+            total_size = grid_data.shape[0]
+            if nx is None or ny is None:
+                raise ValueError("nx and ny must be provided for 1D Taichi fields")
+            if nx * ny != total_size:
+                raise ValueError("nx * ny does not match the size of the Taichi field")
+            data_np = grid_data.to_numpy()
+        else:
+            raise ValueError("Input Taichi field must be 1D or 2D")
     else:
-        # Assume Taichi field - need to determine dimensions
-        # For now, assume square grid - user should provide nx, ny if needed
-        total_size = grid_data.shape[0] if hasattr(grid_data, 'shape') else len(grid_data)
-        nx = ny = int(np.sqrt(total_size))
-        if nx * ny != total_size:
-            raise ValueError("Cannot determine grid dimensions from Taichi field. Please use square grid or convert to numpy first.")
-        source_field = pool.get_temp_field(ti.f32, (total_size,))
-        # Assume field is already populated
-        
+        raise TypeError("grid_data must be a numpy array or Taichi field")
+
+    # Create source field and copy data
+    source_field = pool.get_temp_field(ti.f32, (ny * nx,))
+    source_field.field.from_numpy(data_np)
+
     # Create target field for upscaled result
     target_size = (2 * ny) * (2 * nx)
     target_field = pool.get_temp_field(ti.f32, (target_size,))
-    
-    # Note: Taichi random state is global, seeding happens at ti.init() level
-    
+
     # Execute upscaling kernel
     double_resolution_kernel(
-        source_field.field, 
-        target_field.field, 
-        nx, ny, 
-        noise_amplitude, 
-        seed
+        source_field.field,
+        target_field.field,
+        nx,
+        ny,
+        noise_amplitude,
     )
-    
+
     if return_field:
         # Release source field and return target field
         source_field.release()

--- a/tests/unit/test_rastermanip.py
+++ b/tests/unit/test_rastermanip.py
@@ -6,11 +6,11 @@ Tests basic functionality without complex setup/teardown.
 Author: B.G.
 """
 
-import pytest
 import numpy as np
+import pytest
 import taichi as ti
-from pyfastflow.rastermanip import double_resolution, halve_resolution
 
+from pyfastflow.rastermanip import double_resolution, halve_resolution
 
 # Initialize Taichi once for the entire test module
 ti.init(arch=ti.cpu)
@@ -26,10 +26,10 @@ def test_basic_double_resolution():
     """Test basic doubling of resolution."""
     # Simple 2x2 test grid
     original = np.array([[1, 2], [3, 4]], dtype=np.float32)
-    
+
     # Double resolution
     result = double_resolution(original, noise_amplitude=0.0)
-    
+
     # Check output dimensions
     assert result.shape == (4, 4)
     assert np.all(np.isfinite(result))
@@ -38,18 +38,16 @@ def test_basic_double_resolution():
 def test_basic_halve_resolution():
     """Test basic halving of resolution."""
     # Simple 4x4 test grid where each 2x2 block has known values
-    original = np.array([
-        [1, 2, 5, 6],
-        [3, 4, 7, 8],
-        [9, 10, 13, 14],
-        [11, 12, 15, 16]
-    ], dtype=np.float32)
-    
-    result = halve_resolution(original, method='mean')
-    
+    original = np.array(
+        [[1, 2, 5, 6], [3, 4, 7, 8], [9, 10, 13, 14], [11, 12, 15, 16]],
+        dtype=np.float32,
+    )
+
+    result = halve_resolution(original, method="mean")
+
     # Check dimensions
     assert result.shape == (2, 2)
-    
+
     # Check mean calculations
     expected = np.array([[2.5, 6.5], [10.5, 14.5]], dtype=np.float32)
     assert np.allclose(result, expected)
@@ -57,23 +55,21 @@ def test_basic_halve_resolution():
 
 def test_halve_methods():
     """Test different halving methods."""
-    original = np.array([
-        [1, 2, 5, 6],
-        [3, 4, 7, 8],
-        [9, 10, 13, 14], 
-        [11, 12, 15, 16]
-    ], dtype=np.float32)
-    
+    original = np.array(
+        [[1, 2, 5, 6], [3, 4, 7, 8], [9, 10, 13, 14], [11, 12, 15, 16]],
+        dtype=np.float32,
+    )
+
     # Test different methods
-    result_max = halve_resolution(original, method='max')
-    result_min = halve_resolution(original, method='min')
-    result_mean = halve_resolution(original, method='mean')
-    
+    result_max = halve_resolution(original, method="max")
+    result_min = halve_resolution(original, method="min")
+    result_mean = halve_resolution(original, method="mean")
+
     # All should have same dimensions
     assert result_max.shape == (2, 2)
     assert result_min.shape == (2, 2)
     assert result_mean.shape == (2, 2)
-    
+
     # Max should be >= mean >= min
     assert np.all(result_max >= result_mean)
     assert np.all(result_mean >= result_min)
@@ -82,12 +78,73 @@ def test_halve_methods():
 def test_invalid_method():
     """Test error handling for invalid method."""
     original = np.ones((4, 4), dtype=np.float32)
-    
+
     with pytest.raises(ValueError):
-        halve_resolution(original, method='invalid')
+        halve_resolution(original, method="invalid")
 
 
 def test_odd_dimensions_error():
     """Test error handling for odd dimensions."""
     with pytest.raises(ValueError):
         halve_resolution(np.ones((3, 4), dtype=np.float32))
+
+
+def test_double_resolution_taichi_field_non_square():
+    """Double resolution should handle non-square Taichi fields."""
+    field = ti.field(dtype=ti.f32, shape=(3, 5))
+    for j in range(3):
+        for i in range(5):
+            field[j, i] = j * 5 + i
+
+    result = double_resolution(field, noise_amplitude=0.0)
+    assert result.shape == (6, 10)
+
+
+def test_halve_resolution_taichi_field_non_square():
+    """Halving should handle non-square Taichi fields."""
+    field = ti.field(dtype=ti.f32, shape=(4, 6))
+    for j in range(4):
+        for i in range(6):
+            field[j, i] = j * 6 + i
+
+    result = halve_resolution(field, method="mean")
+    assert result.shape == (2, 3)
+
+
+def test_halve_cubic_linear_plane():
+    """Cubic halving should reproduce values of a linear plane."""
+    nx, ny = 8, 8
+    grid = np.zeros((ny, nx), dtype=np.float32)
+    for j in range(ny):
+        for i in range(nx):
+            grid[j, i] = i + j
+
+    result = halve_resolution(grid, method="cubic")
+
+    def cubic_interp(v0, v1, v2, v3, t):
+        a = -0.5 * v0 + 1.5 * v1 - 1.5 * v2 + 0.5 * v3
+        b = v0 - 2.5 * v1 + 2.0 * v2 - 0.5 * v3
+        c = -0.5 * v0 + 0.5 * v2
+        d = v1
+        return ((a * t + b) * t + c) * t + d
+
+    expected = np.zeros((ny // 2, nx // 2), dtype=np.float32)
+    for tj in range(ny // 2):
+        for ti_out in range(nx // 2):
+            center_j = tj * 2.0 + 0.5
+            center_i = ti_out * 2.0 + 0.5
+            base_j = int(np.floor(center_j))
+            base_i = int(np.floor(center_i))
+            frac_j = center_j - base_j
+            frac_i = center_i - base_i
+            row_vals = []
+            for dj in range(4):
+                jj = np.clip(base_j + dj - 1, 0, ny - 1)
+                samples = []
+                for di in range(4):
+                    ii = np.clip(base_i + di - 1, 0, nx - 1)
+                    samples.append(grid[jj, ii])
+                row_vals.append(cubic_interp(*samples, frac_i))
+            expected[tj, ti_out] = cubic_interp(*row_vals, frac_j)
+
+    assert np.allclose(result, expected)


### PR DESCRIPTION
## Summary
- remove unused seed parameter and fix relative offset in upscaling
- implement true bicubic downscaling and accept explicit field shapes
- add tests for non-square Taichi fields and bicubic interpolation

## Testing
- `ruff check pyfastflow/rastermanip/upscaling.py pyfastflow/rastermanip/downscaling.py tests/unit/test_rastermanip.py`
- `pytest tests/unit/test_rastermanip.py -q`


------
